### PR TITLE
Reset ball speed & point ball towards enemy on score

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -43,13 +43,15 @@ class GameWindow < Gosu::Window
       @blip_sound.play
       increase_speed
     elsif @ball.x <= 0
+      @ball.x = @player.right
       score[1] += 1
-      @ball.reflect_horizontal
+      @ball.v[:x] = 4
       flash_side(:left)
       @explosion_sound.play
     elsif @ball.right >= self.width
+      @ball.x = @enemy.left
       score[0] += 1
-      @ball.reflect_horizontal
+      @ball.v[:x] = -4
       flash_side(:right)
       @explosion_sound.play
     end


### PR DESCRIPTION
Preventing breakout style score loop behind the paddle.

![pongo](https://cloud.githubusercontent.com/assets/433852/12326463/f5f4fc1e-ba9e-11e5-9abf-38d1aa15fb23.gif)

Note: the ball can move too fast for the paddle to catch. You may have to calculate the ball's X & Y vector to do this:

```
if (ball is one or greater vector step away from the paddle it's heading towards) {
     move ball its full vector this step
} else {
    #the ball is moving at say, v[:x] = -10 but ball.x = 2.
    #calculate percentage of total vector distance away the ball is from its target paddle
    #move ball by that amount, allowing for paddle collision
    #otherwise the ball would move -10 and go through the paddle
}
```
